### PR TITLE
Fix deprecation warnings for newer Python versions and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+
+name: CI
+
+jobs:
+  test:
+    name: Test Python ${{ matrix.python }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install package and dependencies
+        run: |
+          pip install .
+          pip install pandas numpy
+      - name: Run 🐼.🐍
+        run: |
+          pythonji example/🐼.🐍

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,11 @@ classifiers        = [
     "Operating System :: MacOS",
     "Operating System :: Microsoft",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 keywords           = "python emoji"

--- a/pythonji/__main__.py
+++ b/pythonji/__main__.py
@@ -35,7 +35,7 @@ def demojize(py_path):
 class EmojiTransformer(ast.NodeTransformer):
     def visit_Str(self, node):
         return ast.copy_location(
-            ast.Constant(s=emoji.emojize(node.s, delimiters=DELIMITERS)), node
+            ast.Constant(value=emoji.emojize(node.value, delimiters=DELIMITERS)), node
         )
 
 

--- a/pythonji/__main__.py
+++ b/pythonji/__main__.py
@@ -35,7 +35,7 @@ def demojize(py_path):
 class EmojiTransformer(ast.NodeTransformer):
     def visit_Str(self, node):
         return ast.copy_location(
-            ast.Str(s=emoji.emojize(node.s, delimiters=DELIMITERS)), node
+            ast.Constant(s=emoji.emojize(node.s, delimiters=DELIMITERS)), node
         )
 
 


### PR DESCRIPTION
`ast.Str` is deprecated and will be removed in Python 3.14