### PR TITLE
Set globals to {}

### DIFF
--- a/pythonji/__main__.py
+++ b/pythonji/__main__.py
@@ -50,7 +50,9 @@ def emojize_literals(text):
 
 def execute(py_path, python_ast):
     """Run Python on the given AST"""
-    exec(compile(python_ast, py_path, mode="exec"))
+    _source = compile(python_ast, py_path, mode="exec")
+    _globals = {}
+    exec(_source, _globals)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3 

When you don't set the `globals` in `exec`, they get inherited from the point where `exec` is called. Then, `pd` won't get added to the globals while running the method.

Debugging pythonji with `globals` set:

https://github.com/gahjelle/pythonji/assets/29506042/8b2700b4-3a33-4453-8097-119a9b3ff021

Debugging pythonji without setting `globals`:

https://github.com/gahjelle/pythonji/assets/29506042/575feef3-4a29-42d5-b572-470a5688ad87