### PR TITLE
Set encoding to utf-8

### DIFF
--- a/pythonji/__main__.py
+++ b/pythonji/__main__.py
@@ -27,7 +27,7 @@ def run(py_file):
 
 def demojize(py_path):
     """Replace emojis by strings in the given file"""
-    py_text = py_path.read_text()
+    py_text = py_path.read_text(encoding="utf-8")
     python_text = emoji.demojize(py_text, delimiters=DELIMITERS)
     return emojize_literals(python_text)
 


### PR DESCRIPTION
Closes #1 
On windows, the default encoding is not utf-8 which causes the `read_text` to fail.